### PR TITLE
Always quote strings with colons

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -175,11 +175,11 @@ bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
   static const RegEx& disallowed_flow =
       Exp::EndScalarInFlow() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::Colon();
   static const RegEx& disallowed_block =
       Exp::EndScalar() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::Colon();
   const RegEx& disallowed =
       flowType == FlowType::Flow ? disallowed_flow : disallowed_block;
 

--- a/src/exp.h
+++ b/src/exp.h
@@ -32,6 +32,10 @@ inline const RegEx& Tab() {
   static const RegEx e = RegEx('\t');
   return e;
 }
+inline const RegEx& Colon() {
+  static const RegEx e = RegEx(':');
+  return e;
+}
 inline const RegEx& Blank() {
   static const RegEx e = Space() | Tab();
   return e;

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -455,6 +455,12 @@ class NodeEmitterTest : public ::testing::Test {
   }
 };
 
+TEST_F(NodeEmitterTest, StringWithColons) {
+  Node node{"String:with:colons"};
+
+  ExpectOutput("\"String:with:colons\"", node);
+}
+
 TEST_F(NodeEmitterTest, SimpleFlowSeqNode) {
   Node node;
   node.SetStyle(EmitterStyle::Flow);


### PR DESCRIPTION
Otherwise they may get misinterpreted, or cause a syntax error even.